### PR TITLE
 VTMD: configure prelocking for ..as of.. stmt

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6429,7 +6429,7 @@ static bool execute_sqlcom_select(THD *thd, TABLE_LIST *all_tables)
         VTMD_exists *vtmd= new (vtmd_array + i) VTMD_exists(*table);
         if (vtmd->check_exists(thd))
           return 1;
-        vtmd->prepare_for_read(thd);
+        vtmd->add_to_prelocking_list(thd);
         i++;
       }
     }

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6406,23 +6406,31 @@ static bool execute_sqlcom_select(THD *thd, TABLE_LIST *all_tables)
   if (check_dependencies_in_with_clauses(lex->with_clauses_list))
     return 1;
 
+  Dynamic_array<VTMD_exists> vtmd_array;
+
   if (thd->variables.vers_alter_history == VERS_ALTER_HISTORY_SURVIVE)
   {
     for (TABLE_LIST *table= all_tables; table; table= table->next_local)
     {
       if (table->vers_conditions)
       {
-        VTMD_exists vtmd(*table);
-        if (vtmd.check_exists(thd))
+        vtmd_array.append(*table);
+        if (vtmd_array.back()->check_exists(thd))
           return 1;
-        if (vtmd.exists && vtmd.setup_select(thd))
-          return 1;
+        vtmd_array.back()->prepare_for_read(thd);
       }
     }
   }
 
   if (!(res= open_and_lock_tables(thd, all_tables, TRUE, 0)))
   {
+    for (size_t i = 0; i < vtmd_array.elements(); i++)
+    {
+      VTMD_exists &vtmd = vtmd_array.at(i);
+      if (vtmd.exists && vtmd.setup_select(thd))
+        return 1;
+    }
+
     if (lex->describe)
     {
       /*

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -1179,6 +1179,7 @@ mysqld_show_create_get_fields(THD *thd, TABLE_LIST *table_list,
   /* We want to preserve the tree for views. */
   thd->lex->context_analysis_only|= CONTEXT_ANALYSIS_ONLY_VIEW;
 
+  if (!table_list->table) /* table could be preopened by vtmd */
   {
     /*
       Use open_tables() directly rather than
@@ -1299,7 +1300,12 @@ mysqld_show_create(THD *thd, TABLE_LIST *table_list)
   if (versioned)
   {
     DBUG_ASSERT(table_list->vers_conditions == FOR_SYSTEM_TIME_AS_OF);
-    VTMD_table vtmd(*table_list);
+    VTMD_exists vtmd(*table_list);
+    if (vtmd.check_exists(thd))
+      goto exit;
+    vtmd.prepare_for_read(thd);
+    if (open_and_lock_tables(thd, table_list, TRUE, 0))
+      goto exit;
     if (vtmd.setup_select(thd))
       goto exit;
   }

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -1300,7 +1300,7 @@ mysqld_show_create(THD *thd, TABLE_LIST *table_list)
   if (versioned)
   {
     DBUG_ASSERT(table_list->vers_conditions == FOR_SYSTEM_TIME_AS_OF);
-    VTMD_exists vtmd(*table_list);
+    VTMD_exists &vtmd = *new (thd->alloc(sizeof(VTMD_exists))) VTMD_exists(*table_list);
     if (vtmd.check_exists(thd))
       goto exit;
     vtmd.prepare_for_read(thd);

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -1303,7 +1303,7 @@ mysqld_show_create(THD *thd, TABLE_LIST *table_list)
     VTMD_exists &vtmd = *new (thd->alloc(sizeof(VTMD_exists))) VTMD_exists(*table_list);
     if (vtmd.check_exists(thd))
       goto exit;
-    vtmd.prepare_for_read(thd);
+    vtmd.add_to_prelocking_list(thd);
     if (open_and_lock_tables(thd, table_list, TRUE, 0))
       goto exit;
     if (vtmd.setup_select(thd))

--- a/sql/vtmd.cc
+++ b/sql/vtmd.cc
@@ -86,6 +86,22 @@ VTMD_table::find_record(ulonglong sys_trx_end, bool &found)
 }
 
 
+void
+VTMD_table::prepare_for_read(THD *thd)
+{
+  vtmd.init_one_table_for_prelocking(
+    DB_WITH_LEN(about),
+    XSTRING_WITH_LEN(vtmd_name),
+    vtmd_name,
+    TL_READ,
+    true,
+    thd->lex->query_tables->belong_to_view,
+    thd->lex->query_tables->trg_event_map,
+    &thd->lex->query_tables_last);
+
+  vtmd.prelocking_placeholder = TABLE_LIST::USER;
+}
+
 bool
 VTMD_table::open(THD *thd, Local_da &local_da, bool *created)
 {
@@ -525,16 +541,18 @@ VTMD_table::find_archive_name(THD *thd, String &out)
   SELECT_LEX &select_lex= thd->lex->select_lex;
 
   Local_da local_da(thd, ER_VERS_VTMD_ERROR);
-  if (open(thd, local_da))
-    return true;
+
+  // tables should be already locked before running this method
+  DBUG_ASSERT(thd->locked_tables_mode);
 
   Name_resolution_context &ctx= thd->lex->select_lex.context;
   TABLE_LIST *table_list= ctx.table_list;
   TABLE_LIST *first_name_resolution_table= ctx.first_name_resolution_table;
   table_map map = vtmd.table->map;
-  ctx.table_list= &vtmd;
+  ctx.table_list= &vtmd; //thd->lex->query_tables;
   ctx.first_name_resolution_table= &vtmd;
   vtmd.table->map= 1;
+  vtmd.table->use_all_columns();
 
   vtmd.vers_conditions= about.vers_conditions;
   if ((error= vers_setup_select(thd, &vtmd, &conds, &select_lex)) ||
@@ -570,7 +588,6 @@ err:
   ctx.table_list= table_list;
   ctx.first_name_resolution_table= first_name_resolution_table;
   vtmd.table->map= map;
-  close_log_table(thd, &open_tables_backup);
   DBUG_ASSERT(!error || local_da.is_error());
   return error;
 }

--- a/sql/vtmd.cc
+++ b/sql/vtmd.cc
@@ -543,7 +543,7 @@ VTMD_table::find_archive_name(THD *thd, String &out)
   Local_da local_da(thd, ER_VERS_VTMD_ERROR);
 
   // tables should be already locked before running this method
-  DBUG_ASSERT(thd->locked_tables_mode);
+   DBUG_ASSERT(thd->lock);
 
   Name_resolution_context &ctx= thd->lex->select_lex.context;
   TABLE_LIST *table_list= ctx.table_list;

--- a/sql/vtmd.cc
+++ b/sql/vtmd.cc
@@ -87,7 +87,7 @@ VTMD_table::find_record(ulonglong sys_trx_end, bool &found)
 
 
 void
-VTMD_table::prepare_for_read(THD *thd)
+VTMD_table::add_to_prelocking_list(THD *thd)
 {
   vtmd.init_one_table_for_prelocking(
     DB_WITH_LEN(about),
@@ -549,7 +549,7 @@ VTMD_table::find_archive_name(THD *thd, String &out)
   TABLE_LIST *table_list= ctx.table_list;
   TABLE_LIST *first_name_resolution_table= ctx.first_name_resolution_table;
   table_map map = vtmd.table->map;
-  ctx.table_list= &vtmd; //thd->lex->query_tables;
+  ctx.table_list= &vtmd;
   ctx.first_name_resolution_table= &vtmd;
   vtmd.table->map= 1;
   vtmd.table->use_all_columns();

--- a/sql/vtmd.h
+++ b/sql/vtmd.h
@@ -55,9 +55,6 @@ protected:
   TABLE_LIST &about;
   SString_t vtmd_name;
 
-private:
-  VTMD_table(const VTMD_table&); // prohibit copying references
-
 public:
   enum {
     FLD_START= 0,
@@ -81,7 +78,8 @@ public:
 
   bool create(THD *thd);
   bool find_record(ulonglong sys_trx_end, bool &found);
-  bool open(THD *thd, Local_da &local_da, bool *created= NULL);
+  void prepare_for_read(THD *thd);
+  bool open(THD *thd, Local_da &local_da, bool *created);
   bool update(THD *thd, const char* archive_name= NULL);
   bool setup_select(THD *thd);
 

--- a/sql/vtmd.h
+++ b/sql/vtmd.h
@@ -78,7 +78,7 @@ public:
 
   bool create(THD *thd);
   bool find_record(ulonglong sys_trx_end, bool &found);
-  void prepare_for_read(THD *thd);
+  void add_to_prelocking_list(THD *thd);
   bool open(THD *thd, Local_da &local_da, bool *created);
   bool update(THD *thd, const char* archive_name= NULL);
   bool setup_select(THD *thd);


### PR DESCRIPTION
Problem:
When nested queries are used inside `as of` statement, needed tables
are locked before execution, but whole thread tables are unlocked after
it. So, we unlock tables that shouldn't be unlocked. This affects `select`
and `show create table` queries.

Solution:
Nested locking is forbidden. Instead, all tables are to be opened at
once. So we add all vtmd tables to lexer's table list and then open
them in a row with other tables used in query.